### PR TITLE
Fix Pressure example

### DIFF
--- a/examples/Pressure/Pressure.ino
+++ b/examples/Pressure/Pressure.ino
@@ -17,6 +17,9 @@
 
 // the setup function runs once when you press reset or power the board
 void setup() {
+    //Initiate the Wire library and join the I2C bus
+    Wire.begin();
+    
     smePressure.begin();
     SerialUSB.begin(115200);
 }


### PR DESCRIPTION
Add `Wire.begin()` to initiate the Wire library and join the I2C bus.
Same problem than [sme-hts221-library #1 issue](https://github.com/ameltech/sme-hts221-library/issues/1).
